### PR TITLE
Concurrency fix

### DIFF
--- a/src/jquery.jqote2.loader.js
+++ b/src/jquery.jqote2.loader.js
@@ -8,8 +8,7 @@
 	var error = new Error( "A template URL must be provided." )
 	  , obj   = Object.prototype
 	  , cache = {}
-	  , options
-	  , callback;
+	  , requests = {};
 	
 	/**
 	 * Pre-processes each template contained within the templates
@@ -24,7 +23,8 @@
 	 * is returned.
 	 */
 	var _preprocess = function(file) {
-		var templates = $(file).filter(options.element || 'script')
+		var options = requests[this.url].options
+		  , templates = $(file).filter(options.element || 'script')
 		  , template
 		  , i,n;
 		  
@@ -35,8 +35,8 @@
 				cache[template.id] = $.jqotec(template);
 			}
 		}
-		callback(cache);
-		options = callback = null;
+		requests[this.url].callback(cache);
+		delete requests[this.url];
 	};
 	
 	/**
@@ -97,7 +97,7 @@
 	 * 
 	 */
 	var _jqoteload = function(opts, success) {
-		var defaults, type;
+		var defaults, type, options;
 		if (opts || opts.url) {
 			options  = null;
 			type = typeof opts;
@@ -112,7 +112,7 @@
 			else if (type === 'string') {
 				options = $.extend( defaults, {url: opts} );
 			}
-			callback = success; 
+			requests[options.url] = { options: options, callback: success};
 			return $.get( options.url ).success( options.preprocess ? _preprocess : success );	
 		}
 		throw error;

--- a/test/jqote2.tpl.loader.test.html
+++ b/test/jqote2.tpl.loader.test.html
@@ -2,10 +2,10 @@
 <html>
     <head>
     	<meta charset="utf-8">
-        <link rel="stylesheet" href="http://code.jquery.com/qunit/git/qunit.css" type="text/css" media="screen">
+        <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-git.css" type="text/css" media="screen">
 		<script src="http://code.jquery.com/jquery-1.7.1.min.js"></script>
-		<script src="http://code.jquery.com/qunit/git/qunit.js"></script>
-		<script src="https://raw.github.com/aefxx/jQote2/master/jquery.jqote2.min.js"></script>
+		<script src="http://code.jquery.com/qunit/qunit-git.js"></script>
+		<script src="https://rawgit.com/aefxx/jQote2/master/jquery.jqote2.min.js"></script>
 		<script src="../src/jquery.jqote2.loader.js"></script>
 		<script src="jqote2.tpl.loader.test.js"></script>
     </head>

--- a/test/jqote2.tpl.loader.test.js
+++ b/test/jqote2.tpl.loader.test.js
@@ -81,7 +81,7 @@ $(document).ready( function()
 	
 	test( "Throws an Error if no options are  provided", function() 
 	{
-		raises( function()
+		throws( function()
 		{ 
 			$.jqoteload( null );
 		}, "Expecting an Error to be thrown when null url and options arguments passed." );


### PR DESCRIPTION
This pull has an actual fix and then a few updates for changes in qunit and github.

The actual fix addresses a problem I found with concurrent jqoteload requests.  Basically, if I called jqoteload twice with the second call before the response had been preprocessed for the first jqoteload, the options and callback values had been set to null.  This is because there was only one options and callback variable.  In order to fix this, I created a requests object with one member for each request.  These members are keyed on the url being requested and preserves the options and callback for each request.
